### PR TITLE
fix "deprecated" warning for roles (mentioned in #11)

### DIFF
--- a/modules/openshift/03-roles.tf
+++ b/modules/openshift/03-roles.tf
@@ -60,5 +60,6 @@ resource "aws_iam_policy_attachment" "openshift-attachment-forward-logs" {
 //  Create a instance profile for the role.
 resource "aws_iam_instance_profile" "openshift-instance-profile" {
   name  = "openshift-instance-profile"
-  roles = ["${aws_iam_role.openshift-instance-role.name}"]
+  role = "${aws_iam_role.openshift-instance-role.name}"
 }
+


### PR DESCRIPTION
Warning from terraform:

```
module.openshift.aws_iam_instance_profile.openshift-instance-profile: "roles": [DEPRECATED] Use `role` instead.
```