### PR TITLE
feat(ci): add support for ci with CircleCI 2, add support for terraform linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,33 @@
 version: 2
+
+# Job defaults, which are common across all jobs.
+job_defaults: &job_defaults
+  working_directory: /terraform-aws-openshift
+  docker:
+    - image: dwmkerr/terraform-ci:0.1.0
+
+# Define the jobs available to the workflow.
 jobs:
-  test:
-    docker:
-      - image: circleci/node:8
+  # Lint the Terraform code.
+  lint:
+    <<: *job_defaults
     steps:
       - checkout
-      - run: make test
+      # Init Terraform.
+      - run: terraform init && terraform get
+      - run:
+          name: Terraform Lint
+          command: make lint
+      # We do not yet run any additional steps, but when we do it is important
+      # to persist terraform state in the workspace.
+      - persist_to_workspace:
+          root: /terraform-aws-openshift
+          paths:
+            - .terraform
 
+# The workflow simply runs the lint job.
 workflows:
   version: 2
   test:
     jobs:
-      - hold:
-          type: approval
-      - test:
-          requires:
-            - hold
+      - lint

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ terraform.tfstate
 # The generated inventory file.
 inventory.cfg
 *.lock.info
+.private.env

--- a/README.md
+++ b/README.md
@@ -38,25 +38,6 @@ I am also adding some 'recipes' which you can use to mix in more advanced featur
 
 <!-- /TOC -->
 
-- [Overview](#overview)
-- [Prerequisites](#prerequisites)
-- [Creating the Cluster](#creating-the-cluster)
-- [Installing OpenShift](#installing-openshift)
-- [Accessing and Managing OpenShift](#accessing-and-managing-openshift)
-	- [OpenShift Web Console](#openshift-web-console)
-	- [The Master Node](#the-master-node)
-	- [The OpenShift Client](#the-openshift-client)
-- [Connecting to the Docker Registry](#connecting-to-the-docker-registry)
-- [Additional Configuration](#additional-configuration)
-- [Choosing the OpenShift Version](#choosing-the-openshift-version)
-- [Destroying the Cluster](#destroying-the-cluster)
-- [Makefile Commands](#makefile-commands)
-- [Pricing](#pricing)
-- [Recipes](#recipes)
-  - [Splunk](#splunk)
-- [Troubleshooting](#troubleshooting)
-- [References](#references)
-
 ## Overview
 
 Terraform is used to create infrastructure as shown:
@@ -256,6 +237,7 @@ There are some commands in the `makefile` which make common operations a little 
 | `make ssh-node1`        | SSH to node 1.                                  |
 | `make ssh-node2`        | SSH to node 2.                                  |
 | `make sample`           | Creates a simple sample project.                |
+| `make lint`             | Lints the terraform code.                       |
 
 ## Pricing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,33 @@ I am also adding some 'recipes' which you can use to mix in more advanced featur
 
 - [Recipe - Splunk](#splunk)
 
-## Index
+**Index**
+
+<!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Creating the Cluster](#creating-the-cluster)
+- [Installing OpenShift](#installing-openshift)
+- [Accessing and Managing OpenShift](#accessing-and-managing-openshift)
+	- [OpenShift Web Console](#openshift-web-console)
+	- [The Master Node](#the-master-node)
+	- [The OpenShift Client](#the-openshift-client)
+- [Connecting to the Docker Registry](#connecting-to-the-docker-registry)
+- [Additional Configuration](#additional-configuration)
+- [Choosing the OpenShift Version](#choosing-the-openshift-version)
+- [Destroying the Cluster](#destroying-the-cluster)
+- [Makefile Commands](#makefile-commands)
+- [Pricing](#pricing)
+- [Recipes](#recipes)
+	- [Splunk](#splunk)
+- [Troubleshooting](#troubleshooting)
+- [Developer Guide](#developer-guide)
+	- [CI](#ci)
+	- [Linting](#linting)
+- [References](#references)
+
+<!-- /TOC -->
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)

--- a/README.md
+++ b/README.md
@@ -289,6 +289,28 @@ systemctl restart origin-master.service
 
 You should now be able to deploy. [More info here](https://github.com/dwmkerr/docs/blob/master/openshift.md#failed-to-pull-image-unsupported-schema-version-2).
 
+## Developer Guide
+
+This section is intended for those who want to update or modify the code.
+
+### CI
+
+[CircleCI 2](https://circleci.com/gh/dwmkerr/terraform-aws-openshift) is used to run builds. You can run a CircleCI build locally with:
+
+```bash
+make circleci
+```
+
+Currently, this build will lint the code (no tests are run).
+
+### Linting
+
+[`tflint`](https://github.com/wata727/tflint) is used to lint the code on the CI server. You can lint the code locally with:
+
+```bash
+make lint
+```
+
 ## References
 
  - https://www.udemy.com/openshift-enterprise-installation-and-configuration - The basic structure of the network is based on this course.

--- a/makefile
+++ b/makefile
@@ -42,8 +42,18 @@ sample:
 	oc new-project sample
 	oc process -f ./sample/counter-service.yml | oc create -f - 
 
+# Lint the terraform files. Don't forget to provide the 'region' var, as it is
+# not provided by default. Error on issues, suitable for CI.
+lint:
+	TF_VAR_region="us-east-1" tflint --error-with-issues
+
 # Run the tests.
 test:
 	echo "Simulating tests..."
+
+# Run the CircleCI build locally.
+circleci:
+	circleci config validate -c .circleci/config.yml
+	circleci build --job lint
 
 .PHONY: sample

--- a/modules/openshift/04-roles.tf
+++ b/modules/openshift/04-roles.tf
@@ -63,3 +63,9 @@ resource "aws_iam_instance_profile" "openshift-instance-profile" {
   role = "${aws_iam_role.openshift-instance-role.name}"
 }
 
+//  Create a instance profile for the bastion. All profiles need a role, so use
+//  our simple openshift instance role.
+resource "aws_iam_instance_profile" "bastion-instance-profile" {
+  name  = "bastion-instance-profile"
+  role = "${aws_iam_role.openshift-instance-role.name}"
+}

--- a/modules/openshift/05-nodes.tf
+++ b/modules/openshift/05-nodes.tf
@@ -29,6 +29,7 @@ resource "aws_instance" "master" {
   //  We need at least 30GB for OpenShift, let's be greedy...
   root_block_device {
     volume_size = 50
+    volume_type = "gp2"
   }
 
   # Storage for Docker, see:
@@ -36,6 +37,7 @@ resource "aws_instance" "master" {
   ebs_block_device {
     device_name = "/dev/sdf"
     volume_size = 80
+    volume_type = "gp2"
   }
 
   key_name = "${aws_key_pair.keypair.key_name}"
@@ -71,6 +73,7 @@ resource "aws_instance" "node1" {
   //  We need at least 30GB for OpenShift, let's be greedy...
   root_block_device {
     volume_size = 50
+    volume_type = "gp2"
   }
 
   # Storage for Docker, see:
@@ -78,6 +81,7 @@ resource "aws_instance" "node1" {
   ebs_block_device {
     device_name = "/dev/sdf"
     volume_size = 80
+    volume_type = "gp2"
   }
 
   key_name = "${aws_key_pair.keypair.key_name}"
@@ -103,6 +107,7 @@ resource "aws_instance" "node2" {
   //  We need at least 30GB for OpenShift, let's be greedy...
   root_block_device {
     volume_size = 50
+    volume_type = "gp2"
   }
 
   # Storage for Docker, see:
@@ -110,6 +115,7 @@ resource "aws_instance" "node2" {
   ebs_block_device {
     device_name = "/dev/sdf"
     volume_size = 80
+    volume_type = "gp2"
   }
 
   key_name = "${aws_key_pair.keypair.key_name}"

--- a/modules/openshift/07-bastion.tf
+++ b/modules/openshift/07-bastion.tf
@@ -1,8 +1,8 @@
-
 //  Launch configuration for the consul cluster auto-scaling group.
 resource "aws_instance" "bastion" {
   ami                  = "${data.aws_ami.amazonlinux.id}"
   instance_type        = "t2.micro"
+  iam_instance_profile = "${aws_iam_instance_profile.bastion-instance-profile.id}"
   subnet_id            = "${aws_subnet.public-subnet.id}"
 
   security_groups = [


### PR DESCRIPTION
You can now run `make lint` to lint the terraform code:

![image](https://user-images.githubusercontent.com/1926984/36239152-f294578c-1239-11e8-8cc0-7e3105fbf4f8.png)

We now also have a build pipeline in CircleCI 2:

![image](https://user-images.githubusercontent.com/1926984/36239175-1fca4216-123a-11e8-9b24-b8a97602e959.png)