### PR TITLE
Upping Bastion AWS image type as Ansible is run is failing due to lack of memory.

### DIFF
--- a/modules/openshift/08-bastion.tf
+++ b/modules/openshift/08-bastion.tf
@@ -1,7 +1,7 @@
 //  Launch configuration for the consul cluster auto-scaling group.
 resource "aws_instance" "bastion" {
   ami                  = "${data.aws_ami.amazonlinux.id}"
-  instance_type        = "t2.micro"
+  instance_type        = "t2.small"
   iam_instance_profile = "${aws_iam_instance_profile.bastion-instance-profile.id}"
   subnet_id            = "${aws_subnet.public-subnet.id}"
 


### PR DESCRIPTION
- Ansible run kept failing with following error:
`ERROR! Unexpected Exception: [Errno 12] Cannot allocate memory`
- Increased the memory on the Bastion host by changing the AWS image from t2.micro to  type t2.small to resolve the issue.

Thanks for sharing this repo!
