### PR TITLE
adding egress on 8443 to enable cluster-console

### DIFF
--- a/modules/openshift/04-security-groups.tf
+++ b/modules/openshift/04-security-groups.tf
@@ -98,7 +98,15 @@ resource "aws_security_group" "openshift-public-egress" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
+  
+  //  CUSTOM - To allow for cluster-console login
+  egress {
+    from_port   = 8443
+    to_port     = 8443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
   //  Use our common tags and add a specific name.
   tags = "${merge(
     local.common_tags,


### PR DESCRIPTION
this egress rule corrects the issue where the 'cluster-console' cannot be accessed due to the master node not being able to connect to the external xip.io URL on port 8443.